### PR TITLE
Minor fix: NPLBroker object storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "npl-broker",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A NPL brokerage standard (EVS01) implemented on NodeJS for HotPocket instances to manage their NPL rounds in a systematic manner.",
   "main": "index.js",
   "scripts": {
-    "test": "sudo hpdevkit clean && sudo npm link && cd test/unit_test/src && sudo npm link npl-broker && sudo HP_CLUSTER_SIZE=6 npm start"
+    "test": "sudo hpdevkit clean && sudo npm link && cd test/general/src && sudo npm link npl-broker && sudo HP_CLUSTER_SIZE=6 npm start"
   },
   "repository": {
     "type": "git",
@@ -25,7 +25,6 @@
     "hpdevkit": "^0.6.5"
   },
   "dependencies": {
-    "crypto": "^1.0.1",
     "events": "^3.3.0"
   }
 }

--- a/test/general/dist/NPL/objectStorage.js
+++ b/test/general/dist/NPL/objectStorage.js
@@ -1,0 +1,27 @@
+let _object = null;
+
+/**
+ * Get the NPLBroker instance
+ * 
+ * @returns {object}
+ */
+function get() {
+    return _object
+}
+
+/**
+ * Set the NPLBroker instance
+ * 
+ * @param {object} object The NPLBroker instance
+ * @returns {object}
+ */
+function set(object) {
+    if (_object === null) {
+        _object = object;
+    }
+}
+
+module.exports = {
+    get,
+    set
+}

--- a/test/general/dist/index.js
+++ b/test/general/dist/index.js
@@ -6,11 +6,12 @@
 
 const EventEmitter = __nccwpck_require__(361);
 const crypto = __nccwpck_require__(113);
+const objectStorage = __nccwpck_require__(907) // the location for the NPLBroker instance (singleton pattern)
 
 /**
 * NPL Broker for HotPocket applications.
 * @author Wo Jake & Mark
-* @version 1.2.2
+* @version 1.3.1
 * @description A NPL brokerage module (EVS-01) for HotPocket dApps to manage their NPL rounds.
 * 
 * See https://github.com/Evernerd/npl-broker-js to learn more and contribute to the codebase, any contribution is truly appreciated!
@@ -24,34 +25,54 @@ const crypto = __nccwpck_require__(113);
 
 // Chunk transfer reference: https://datatracker.ietf.org/doc/html/rfc9112#section-7.1
 
-/**
-* The NPL Broker instance.
-*/
-let instance;
-
 class NPLBroker extends EventEmitter {
     /**
     * @param {*} ctx - The HotPocket contract's context.
+    * @param {Function} stream - The listener function for NPL stream.
     */
-    constructor(ctx) {
+    constructor(ctx, stream) {
         super();
         
-        this._ctx = ctx;
+        this.unl = ctx.unl;
+        this.stream = stream ?? undefined;
         
         /**
         * Turn on the NPL channel on this HP instance.
         */
-        ctx.unl.onMessage((node, payload, timeTaken = performance.now(), {roundName, chunkID, content} = JSON.parse(payload)) => {
-            this.emit(roundName, {
-                node: node.publicKey,
-                chunkID: chunkID,
-                content: content,
-                timeTaken: timeTaken
-            });
+        ctx.unl.onMessage((node, payload, timeTaken = performance.now(), {roundName, chunkID, content, checksum} = JSON.parse(payload)) => {
+            // !!! Dev note: DO NOT USE "stream" as an NPL round name as it is used to stream non-tagged NPL messages !!!
+            if (roundName === "stream") {
+                this.emit(roundName, {node: node, payload: content});
+            } else {
+                this.emit(roundName, {
+                    node: node.publicKey,
+                    chunkID: chunkID ?? undefined,
+                    content: content,
+                    checksum: checksum,
+                    timeTaken: timeTaken
+                });
+            }
         });
+        
+        if (this.stream !== undefined) {
+            this.on("stream", this.stream);
+        }
         
         this.setMaxListeners(Infinity);
     }
+    
+    /**
+    * Broadcast a non-tagged NPL message.
+    * 
+    * @param {*} packet 
+    */
+    async send(packet) {
+        await this.unl.send(JSON.stringify({
+            roundName: "stream",
+            content: packet
+        }));
+    }
+    
     
     /**
     * Subscribe to an NPL round name.
@@ -87,10 +108,11 @@ class NPLBroker extends EventEmitter {
     * @param {string} roundName - The NPL round name. This *must* be unique.
     * @param {*} content - The content that will be distributed to this instance's peers.
     * @param {number} desiredCount - The desired count of NPL messages to collect.
+    * @param {boolean} checksum - Check the content's integrity upon arrival (Content Integrity)
     * @param {number} timeout - The time interval given to this NPL round to conclude.
     * @returns {object}
     */
-    async performNplRound({roundName, content, desiredCount, timeout, checksum, /**retransmission*/}, startingTime = performance.now()) {
+    async performNplRound({roundName, content, desiredCount, checksum, timeout, /**retransmission*/}, startingTime = performance.now()) {
         if (typeof roundName !== "string") {
             throw new Error(`roundName type is not valid, must be string`);
         }
@@ -103,20 +125,20 @@ class NPLBroker extends EventEmitter {
         if (!Number.isInteger(desiredCount)) {
             throw new Error(`desiredCount value is not valid, must be a whole number`);
         }
+        if (checksum !== undefined && typeof checksum !== "boolean") {
+            throw new Error(`checksum type is not valid, must be boolean`);
+        }
         if (typeof timeout !== "number") {
             throw new Error(`timeout type is not valid, must be number`);
         }
         if (timeout < 1) {
             throw new Error(`timeout value is not valid, must be a number more than 1`);
         }
-        if (checksum !== undefined && typeof checksum !== Boolean) {
-            throw new Error(`checksum type is not valid, must be boolean`);
-        }
         // if (retransmission !== false || retransmission !== true) {
         //     throw new Error(`retransmission type is not valid, must be boolean`);
         // }
         
-        const NPL = (roundName, desiredCount, timeout, startingTime) => {
+        const receiveNPL = () => {
             return new Promise((resolve) => {
                 /** Record of full NPL messages */
                 var record = [];
@@ -125,59 +147,78 @@ class NPLBroker extends EventEmitter {
                 /** Chunked messages awaiting to be combined once fully received entire message */
                 var message_chunks = {};
                 /** An indicator to tell if the node is receiving chunked messages, enabling chunk transfer mechanism */
-                var chunked_transfer = false;
+                var chunk_transfer = false;
                 
                 /** The object that will be returned to this function's caller. */
                 const response = {
                     roundName: roundName,
                     record: record,
                     desiredCount: desiredCount,
+                    checksum: undefined,
                     timeout: timeout,
-                    timeTaken: undefined
+                    timeTaken: timeout
                 };
                 
-                let timer = setTimeout((roundTimeTaken = performance.now() - startingTime) => {
+                let timer = setTimeout(() => {
                     // Fire up the set timeout if we didn't receive enough NPL messages.
+                                        
                     this.removeListener(roundName, LISTENER_NPL_ROUND_PLACEHOLDER);
-                    
-                    response.timeTaken = roundTimeTaken;
-                    
+
                     resolve(response);
                 }, timeout);
                 
-                const LISTENER_NPL_ROUND_PLACEHOLDER = (packet, nodeTimeTaken = packet.timeTaken - startingTime) => {
+                const LISTENER_NPL_ROUND_PLACEHOLDER = (packet) => {
                     if (!participants.includes(packet.node) || packet.chunkID !== undefined) {
                         if (!participants.includes(packet.node)) {
                             participants.push(packet.node);
                         }
                         if (packet.chunkID !== undefined) {
-                            chunked_transfer = true;
+                            chunk_transfer = true;
                         }
+                        if (packet.checksum !== undefined) {
+                            if (packet.content === null) {
+                                var message = message_chunks[packet.node].join('');
+                            } else {
+                                var message = packet.content;
+                            }
+                            var content_hash = crypto.createHash('sha256').update(message).digest('hex');
+                        } 
                         
-                        if (!chunked_transfer) {
-                            // Whole message transmitted
-                            record.push({
-                                "roundName": roundName,
-                                "node": packet.node,
-                                "content": packet.content,
-                                "timeTaken": nodeTimeTaken
-                            });
+                        if (!chunk_transfer) {
+                            // Whole message transmitted 
+                            if (packet.checksum === content_hash || packet.checksum === undefined) {
+                                record.push({
+                                    "roundName": roundName,
+                                    "node": packet.node,
+                                    "content": packet.content,
+                                    "checksum": packet.checksum,
+                                    "timeTaken": packet.timeTaken - startingTime
+                                });
+                            } else {
+                                // We've received a damaged packet, request retransmission (ACK must be introduced soon in HP enhancement)
+                            }
                         } else {
                             // Chunked messages
                             if (message_chunks[packet.node] === undefined) {
                                 message_chunks[packet.node] = [];
                             }
-
+                            
                             if (packet.content !== null) {
-                                message_chunks[packet.node].push(packet.content);
+                                if (packet.checksum === content_hash || packet.checksum === undefined) {
+                                    message_chunks[packet.node].push(packet.content);
+                                } else {
+                                    // We've received a damaged packet, force stop chunk transfer & request retransmission
+                                }
                             } else {
                                 // Last chunk message indicating the end of the chunk transfer
-                                if (message_chunks[packet.node].length === Number(packet.chunkID)) {
+                                if (message_chunks[packet.node].length === Number(packet.chunkID)
+                                && packet.checksum === content_hash) {
                                     record.push({
                                         "roundName": roundName,
                                         "node": packet.node,
                                         "content": message_chunks[packet.node].join(''),
-                                        "timeTaken": nodeTimeTaken
+                                        "checksum": packet.checksum,
+                                        "timeTaken": packet.timeTaken - startingTime
                                     })
                                 } // else if (packet.retransmission === true) {
                                 //     // Assess which chunk packet was lost via ChunkID check & request for a retransmission of the lost messages
@@ -200,7 +241,7 @@ class NPLBroker extends EventEmitter {
                                 //         console.log("Lost chunks (by ID):", lost_chunkID);
                                 //     });
                                 
-                                //     // DEV NOT: (ADD) We are supposed to send the missing chunks to the sender & request retranmission.
+                                //     // DEV NOT: (ADD) We are supposed to send the missing chunks to the sender & request retransmission.
                                 // }
                             }
                         }
@@ -208,13 +249,11 @@ class NPLBroker extends EventEmitter {
                         // Resolve immediately if we have the desired no. of NPL messages.
                         if (record.length === desiredCount) {
                             clearTimeout(timer);
-                            
-                            const finish = performance.now();
+                                                        
+                            response.timeTaken = performance.now() - startingTime;
                             
                             this.removeListener(roundName, LISTENER_NPL_ROUND_PLACEHOLDER);
-                            
-                            response.timeTaken = finish - startingTime;
-                            
+
                             resolve(response);
                         }
                     } else {
@@ -228,70 +267,66 @@ class NPLBroker extends EventEmitter {
             });
         };
         
-        if (checksum) {
-            // If checksum is true, we'll hash the content for the recipient to be able to verify the content's integrity 
-            var checksum_hash = crypto.createHash('sha256').update(content).digest('hex');
-        }
-        
-        let npl_message = {
-            roundName: roundName,
-            content: content,
-            checksum: checksum_hash
-        }
-        
-        try {
-            const _npl_submission = await this._ctx.unl.send(JSON.stringify(npl_message));
-        } catch (err) {
-            // If it is a recognized error (NPL message size is too large), we proceed with chunk transfer
-            this.size_limit = Number(err.replace(/\D/g, '')) - 60; // (the npl message size limit - JSON format size)
-            
-            console.log(this.size_limit+60)
-            if (npl_message.roundName.length > this.size_limit) {
-                throw new Error(`roundName size is too big`);
+        const sendNPL = async () => {
+            if (checksum) {
+                var checksum_hash = crypto.createHash('sha256').update(content).digest('hex');
             }
             
-            let message_chunks = [];
-            let npl_packets = [];
-            var maxMessageSize = this.size_limit-roundName.length;
-
-            while (npl_message.content.length > 0) {
-                message_chunks.push(npl_message.content.slice(0, maxMessageSize));
-                npl_message.content = npl_message.content.slice(maxMessageSize);
+            let npl_message = {
+                roundName: roundName,
+                content: content,
+                checksum: checksum_hash
             }
-
-            // We divide the NPL message into multiple segments & submit them in chunks
-            message_chunks.forEach((message, index) => {
-                if (checksum) {
-                    var checksum_hash = crypto.createHash('sha256').update(message).digest('hex');
+            
+            try {
+                const _npl_submission = await this.unl.send(JSON.stringify(npl_message));
+            } catch (err) {
+                // If it is a recognized error (NPL message size is too large), we proceed with chunk transfer
+                this.size_limit = Number(err.replace(/\D/g, '')) - 60; // (the npl message size limit - JSON format size)
+                
+                if (npl_message.roundName.length > this.size_limit) {
+                    throw new Error(`roundName size is too big`);
                 }
 
-                if (index !== message_chunks.length - 1) {                
+                let npl_packets = [];
+                const content_hash = crypto.createHash('sha256').update(npl_message.content).digest('hex');
+                const maxMessageSize = this.size_limit-roundName.length;
+                
+                while (npl_message.content.length > 0) {
+                    const message_chunk = npl_message.content.slice(0, maxMessageSize)
+                    if (checksum) {
+                        var checksum_hash = crypto.createHash('sha256').update(message_chunk).digest('hex');
+                    }
+                    
                     npl_packets.push({
                         roundName: roundName,
                         chunkID: npl_packets.length.toString().padStart(4, "0"),
-                        content: message,
+                        content: message_chunk,
                         checksum: checksum_hash
                     });
-                } else {
-                    /** The last chunk packet is empty as it is used to verify that the chunk transfer is finished,
-                    *   The checksum is used to verify the entire transfer's content integrity
-                    */
-                    npl_packets.push({
-                        roundName: roundName,
-                        chunkID: npl_packets.length.toString().padStart(4, "0"),
-                        // retransmission: retransmission,
-                        content: null,
-                        checksum: crypto.createHash('sha256').update(message_chunks.join('')).digest('hex')
-                    });
+                    npl_message.content = npl_message.content.slice(maxMessageSize);
+                    
+                    if (npl_message.content.length === 0) {
+                        // The last chunk packet is empty as it is used to verify that the chunk transfer is finished,
+                        // The checksum is used to verify the entire transfer's content integrity
+                        npl_packets.push({
+                            roundName: roundName,
+                            chunkID: npl_packets.length.toString().padStart(4, "0"),
+                            // retransmission: retransmission,
+                            content: null,
+                            checksum: content_hash
+                        });
+                    }
                 }
-            })
-            
-            npl_packets.forEach(async (element) => {
-                const _npl_submission = await this._ctx.unl.send(JSON.stringify(element));
-            })
+                
+                npl_packets.forEach(async (packet) => {
+                    const _npl_submission = await this.unl.send(JSON.stringify(packet));
+                })
+            }
         }
         
-        const NPL_round_result = await NPL(roundName, desiredCount, timeout, startingTime);
+        await sendNPL();
+        const NPL_round_result = await receiveNPL();
         
         if (NPL_round_result instanceof Error) {
             throw NPL_round_result;
@@ -306,14 +341,17 @@ class NPLBroker extends EventEmitter {
 * Singelton pattern.
 * 
 * @param {object} ctx - The HotPocket contract's context.
+* @param {Function} stream - The listener function for NPL stream.
 * @returns {object}
 */
-function init(ctx) {
+function init(ctx, stream) {
     // Singelton pattern since the intention is to only use NPLBroker instance for direct NPL access.
     // If the NPL broker instance has been initialized, return the broker's instance to the call,
     // this ensures that the broker is accessible to all components of the HP dApp
-    if (!instance) {
-        instance = new NPLBroker(ctx);
+    let instance = objectStorage.get();
+    if (instance === null) {
+        instance = new NPLBroker(ctx, stream);
+        objectStorage.set(instance);
     }
     return instance;
 }
@@ -935,6 +973,14 @@ module.exports = __nccwpck_require__(224);
 /******/ 	
 /******/ })()
 ;
+
+/***/ }),
+
+/***/ 907:
+/***/ ((module) => {
+
+module.exports = eval("require")("./NPL/objectStorage.js");
+
 
 /***/ }),
 

--- a/test/unit_test/dist/NPL/objectStorage.js
+++ b/test/unit_test/dist/NPL/objectStorage.js
@@ -1,0 +1,27 @@
+let _object = null;
+
+/**
+ * Get the NPLBroker instance
+ * 
+ * @returns {object}
+ */
+function get() {
+    return _object
+}
+
+/**
+ * Set the NPLBroker instance
+ * 
+ * @param {object} object The NPLBroker instance
+ * @returns {object}
+ */
+function set(object) {
+    if (_object === null) {
+        _object = object;
+    }
+}
+
+module.exports = {
+    get,
+    set
+}

--- a/tutorial/TUTORIAL.md
+++ b/tutorial/TUTORIAL.md
@@ -1,10 +1,8 @@
-# npl-broker-js tutorial
+`npl-broker-js` is a library that could easily be plug into your HotPocket contract code.
 
-## SLIGHTLY OUTDATED - WE"LL CHANGE THIS SOON (TM)
+The library follows a OOP approach, in which, devs must initialize the object before being able to utilize it.
 
-`npl-broker-js` is a library that you could easily plug into. The library follows a OOP approach, in which, devs must initialize the object before being able to utilize it.
-
-`npl-broker-js` is essentially an [EventEmitter](https://nodejs.dev/en/learn/the-nodejs-event-emitter/) wrapper tailor made to manage HotPocket's NPL channel.
+`npl-broker-js` is event-basedan [EventEmitter](https://nodejs.dev/en/learn/the-nodejs-event-emitter/) wrapper tailor made to manage HotPocket's NPL channel.
 
 Here are all the available features on `npl-broker-js`:
 


### PR DESCRIPTION
The previous version stored the NPLBroker class object in its own file, which *may* introduce problems in the future where libraries use depend on different versions. So we will be storing the object on an external file under `/dist/NPL/objectStorage.js`